### PR TITLE
Сonfirmation of password, errors translation

### DIFF
--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -29,12 +29,24 @@
     "emailLabel": "Email",
     "emailPlaceholder": "Enter your email",
     "phoneLabel": "Phone number",
-    "nameLabel": "Name",
-    "namePlaceholder": "Enter your name",
     "passwordLabel": "Password",
     "passwordPlaceholder": "Enter your password",
+    "confirmPasswordLabel": "Confirm password",
+    "confirmPasswordPlaceholder": "Enter your password",
     "signUp": "Sign Up",
     "successTitle": "Well done! Check your email",
     "errorFallback": "Something went wrong, try again, please"
+  },
+  "validationErrors": {
+    "samePasswordValidator": "Passwords are not matching",
+    "noSymbol": "Email should include @",
+    "noPropperFormat": "Invalid email format, proper format is 'user@example.com'",
+    "noNumbers": "Field should include numbers",
+    "noLowerCaseLetters": "Field should include lowercase letters",
+    "noUpperCaseLetters": "Field should include uppercase letters",
+    "whitespace": "No whitespace allowed",
+    "required": "This field is required",
+    "minlength": "Minimum length — ",
+    "maxlength": "Maximum length — "
   }
 }

--- a/public/assets/i18n/ru.json
+++ b/public/assets/i18n/ru.json
@@ -29,12 +29,24 @@
     "emailLabel": "Эл. почта",
     "emailPlaceholder": "Введите вашу почту",
     "phoneLabel": "Номер телефона",
-    "nameLabel": "Имя",
-    "namePlaceholder": "Введите ваше имя",
     "passwordLabel": "Пароль",
     "passwordPlaceholder": "Введите пароль",
+    "confirmPasswordLabel": "Подтвердите пароль",
+    "confirmPasswordPlaceholder": "Введите пароль",
     "signUp": "Зарегистрироваться",
     "successTitle": "Отлично! Проверьте вашу почту",
     "errorFallback": "Что-то пошло не так, попробуйте ещё раз"
+  },
+  "validationErrors": {
+    "samePasswordValidator": "Пароли не совпадают",
+    "noSymbol": "Адрес электронной почты должен включать @",
+    "noPropperFormat": "Неверный формат адреса электронной почты, правильный формат — 'user@example.com'",
+    "noNumbers": "Поле должно содержать цифры",
+    "noLowerCaseLetters": "Поле должно содержать строчные буквы",
+    "noUpperCaseLetters": "Поле должно содержать заглавные буквы",
+    "whitespace": "Пробелы не допускаются",
+    "required": "Это поле обязательно к заполнению",
+    "minlength": "Минимальная длина — ",
+    "maxlength": "Максимальная длина — "
   }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,8 @@
-import { type CanActivateFn, type Route, Router } from '@angular/router';
-import { inject } from '@angular/core';
-import { LOCAL_STORAGE_KEY } from '@/app/constants/constants';
+import { type Route } from '@angular/router';
+import {
+  anonymousGuardFunction,
+  authenticatedGuardFunction,
+} from '@/app/guards/auth.guard';
 
 export const AppRoutes = {
   MAIN: 'main',
@@ -19,20 +21,6 @@ export const RoutePath: Record<AppRouteType, string> = {
   [AppRoutes.SIGN_UP]: 'signup',
   [AppRoutes.SIGN_IN]: 'signin',
   [AppRoutes.NOT_FOUND]: '**',
-};
-
-const authenticatedGuardFunction: CanActivateFn = () => {
-  const router = inject(Router);
-  const token = localStorage.getItem(LOCAL_STORAGE_KEY);
-
-  return token !== null ? true : router.parseUrl('signin');
-};
-
-const anonymousGuardFunction: CanActivateFn = () => {
-  const router = inject(Router);
-  const token = localStorage.getItem(LOCAL_STORAGE_KEY);
-
-  return token !== null ? router.parseUrl('game') : true;
 };
 
 export const appRoutes: Route[] = [

--- a/src/app/components/game-settings/game-settings.scss
+++ b/src/app/components/game-settings/game-settings.scss
@@ -1,3 +1,3 @@
 .game-setting-wrapper {
-  //background-color: var(--tui-background-neutral-2-pressed);
+  // background-color: var(--tui-background-neutral-2-pressed);
 }

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -1,3 +1,5 @@
 export const minPasswordLength = 7;
+export const minUserNameLength = 3;
 export const maxPasswordLength = 15;
+export const maxUserNameLength = 12;
 export const LOCAL_STORAGE_KEY = 'sb-jnwnlprjvevgdxnngxnr-auth-token';

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,17 @@
+import { type CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { LOCAL_STORAGE_KEY } from '@/app/constants/constants';
+
+export const authenticatedGuardFunction: CanActivateFn = () => {
+  const router = inject(Router);
+  const token = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  return token !== null ? true : router.parseUrl('signin');
+};
+
+export const anonymousGuardFunction: CanActivateFn = () => {
+  const router = inject(Router);
+  const token = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  return token !== null ? router.parseUrl('game') : true;
+};

--- a/src/app/pages/sign-in-page/sign-in-page.ts
+++ b/src/app/pages/sign-in-page/sign-in-page.ts
@@ -1,22 +1,22 @@
 import {
-  TuiIcon,
-  TuiError,
-  TuiLabel,
-  TuiButton,
   TuiAlertService,
+  TuiButton,
+  TuiError,
+  TuiIcon,
+  TuiLabel,
   TuiTextfieldComponent,
   TuiTextfieldDirective,
   TuiTextfieldOptionsDirective,
 } from '@taiga-ui/core';
 import {
-  Validators,
-  ReactiveFormsModule,
   NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
 } from '@angular/forms';
 import {
-  TuiPassword,
+  TUI_VALIDATION_ERRORS,
   TuiFieldErrorPipe,
-  tuiValidationErrorsProvider,
+  TuiPassword,
 } from '@taiga-ui/kit';
 import { Store } from '@ngrx/store';
 import { firstValueFrom } from 'rxjs';
@@ -30,6 +30,10 @@ import { Navigation } from '../../components/navigation/navigation';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { UserSupabaseService } from '../../services/user-supabase.service';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  noValidEmailFormat,
+  noWhitespace,
+} from '@/app/utilities/validation-funtions';
 
 @Component({
   selector: 'app-sign-in-page',
@@ -51,10 +55,22 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
     TranslatePipe,
   ],
   providers: [
-    tuiValidationErrorsProvider({
-      required: 'This field is required',
-      email: 'Enter a valid email address',
-    }),
+    {
+      provide: TUI_VALIDATION_ERRORS,
+      useFactory: (translate: TranslateService): unknown => {
+        translate.stream('validationErrors.required');
+        return {
+          required: translate.get('validationErrors.required'),
+          minlength: ({ requiredLength }: { requiredLength: string }) =>
+            translate.instant('validationErrors.minlength') +
+            `${requiredLength}`,
+          maxlength: ({ requiredLength }: { requiredLength: string }) =>
+            translate.instant('validationErrors.maxlength') +
+            `${requiredLength}`,
+        };
+      },
+      deps: [TranslateService],
+    },
   ],
   standalone: true,
   templateUrl: './sign-in-page.html',
@@ -71,7 +87,7 @@ export class SignInPage {
 
   protected signinForm = this.fb.group({
     email: this.fb.control('', {
-      validators: [Validators.required, Validators.email],
+      validators: [Validators.required, noWhitespace(), noValidEmailFormat()],
     }),
     password: this.fb.control('', {
       validators: [Validators.required],
@@ -79,6 +95,10 @@ export class SignInPage {
   });
 
   protected async signin(): Promise<void> {
+    this.signinForm.markAllAsTouched();
+    if (this.signinForm.invalid) {
+      return;
+    }
     const result = await this.api.signin(this.signinForm.getRawValue());
 
     if (result.error) {

--- a/src/app/pages/sign-up-page/sign-up-page.html
+++ b/src/app/pages/sign-up-page/sign-up-page.html
@@ -40,21 +40,6 @@
           />
         </label>
         <label tuiLabel>
-          {{ "signup.nameLabel" | translate }}
-          <tui-textfield tuiTextfieldSize="m">
-            <input
-              placeholder="{{ 'signup.namePlaceholder' | translate }}"
-              type="text"
-              tuiTextfield
-              formControlName="username"
-            />
-          </tui-textfield>
-          <tui-error
-            formControlName="username"
-            [error]="[] | tuiFieldError | async"
-          />
-        </label>
-        <label tuiLabel>
           {{ "signup.passwordLabel" | translate }}
           <tui-textfield tuiTextfieldSize="m">
             <input
@@ -67,6 +52,24 @@
           </tui-textfield>
           <tui-error
             formControlName="password"
+            [error]="[] | tuiFieldError | async"
+          />
+        </label>
+        <label tuiLabel>
+          {{ "signup.confirmPasswordLabel" | translate }}
+          <tui-textfield tuiTextfieldSize="m">
+            <input
+              placeholder="{{
+                'signup.confirmPasswordPlaceholder' | translate
+              }}"
+              type="password"
+              tuiTextfield
+              formControlName="confirmPassword"
+            />
+            <tui-icon tuiPassword />
+          </tui-textfield>
+          <tui-error
+            formControlName="confirmPassword"
             [error]="[] | tuiFieldError | async"
           />
         </label>

--- a/src/app/pages/sign-up-page/sign-up-page.scss
+++ b/src/app/pages/sign-up-page/sign-up-page.scss
@@ -7,7 +7,7 @@
 
   height: 100vh;
   margin: 0;
-  background-position: -10rem 35%;
+  background-position: -11rem 35%;
 
   &_container {
     max-width: 29.5rem;
@@ -15,11 +15,7 @@
 
   &_title {
     margin-bottom: 0.9rem;
-    font-size: 2.2rem;
-
-    @media (width <= 800px) and (width >= 530px) {
-      font-size: 1.8rem;
-    }
+    font-size: 1.8rem;
 
     @media (width <= 529px) {
       margin-bottom: 0.4rem;

--- a/src/app/pages/sign-up-page/sign-up-page.ts
+++ b/src/app/pages/sign-up-page/sign-up-page.ts
@@ -14,11 +14,11 @@ import {
   Validators,
 } from '@angular/forms';
 import {
+  TUI_VALIDATION_ERRORS,
   TuiFieldErrorPipe,
   tuiInputPhoneInternationalOptionsProvider,
   TuiInputRange,
   TuiPassword,
-  tuiValidationErrorsProvider,
 } from '@taiga-ui/kit';
 import {
   TuiAlertService,
@@ -41,11 +41,12 @@ import {
   minPasswordLength,
 } from '../../constants/constants';
 import {
-  noLowerCaseLetters,
-  noNumbers,
-  noUpperCaseLetters,
+  createSamePasswordValidator,
+  lowerCasePresent,
   noValidEmailFormat,
   noWhitespace,
+  numbersPresent,
+  upperCasePresent,
 } from '../../utilities/validation-funtions';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 
@@ -74,13 +75,22 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
   ],
   providers: [
     tuiInputPhoneInternationalOptionsProvider({ metadata: of(metadata) }),
-    tuiValidationErrorsProvider({
-      required: 'This field is required',
-      minlength: ({ requiredLength }: { requiredLength: string }) =>
-        of(`Minimum length — ${requiredLength}`),
-      maxlength: ({ requiredLength }: { requiredLength: string }) =>
-        `Maximum length — ${requiredLength}`,
-    }),
+    {
+      provide: TUI_VALIDATION_ERRORS,
+      useFactory: (translate: TranslateService): unknown => {
+        translate.stream('validationErrors.required');
+        return {
+          required: translate.get('validationErrors.required'),
+          minlength: ({ requiredLength }: { requiredLength: string }) =>
+            translate.instant('validationErrors.minlength') +
+            `${requiredLength}`,
+          maxlength: ({ requiredLength }: { requiredLength: string }) =>
+            translate.instant('validationErrors.maxlength') +
+            `${requiredLength}`,
+        };
+      },
+      deps: [TranslateService],
+    },
   ],
   templateUrl: './sign-up-page.html',
   styleUrl: './sign-up-page.scss',
@@ -108,30 +118,41 @@ export class SignUpPage {
   ];
   protected countryIsoCode: TuiCountryIsoCode = 'ES';
 
-  protected signupForm = this.fb.group({
-    email: this.fb.control('', {
-      validators: [Validators.required, noWhitespace(), noValidEmailFormat()],
-    }),
-    phone: this.fb.control('', {
-      validators: [Validators.required],
-    }),
-    username: this.fb.control('', {
-      validators: [Validators.required],
-    }),
-    password: this.fb.control('', {
-      validators: [
-        Validators.required,
-        noWhitespace(),
-        Validators.minLength(minPasswordLength),
-        Validators.maxLength(maxPasswordLength),
-        noUpperCaseLetters(),
-        noLowerCaseLetters(),
-        noNumbers(),
-      ],
-    }),
-  });
+  protected signupForm = this.fb.group(
+    {
+      email: this.fb.control('', {
+        validators: [Validators.required, noWhitespace(), noValidEmailFormat()],
+      }),
+      phone: this.fb.control('', {
+        validators: [Validators.required],
+      }),
+      username: this.fb.control('', {
+        validators: [Validators.required],
+      }),
+      password: this.fb.control('', {
+        validators: [
+          Validators.required,
+          noWhitespace(),
+          Validators.minLength(minPasswordLength),
+          Validators.maxLength(maxPasswordLength),
+          upperCasePresent(),
+          lowerCasePresent(),
+          numbersPresent(),
+        ],
+      }),
+      confirmPassword: this.fb.control(''),
+    },
+    {
+      validators: [createSamePasswordValidator()],
+    },
+  );
 
   protected async signup(): Promise<void> {
+    this.signupForm.markAllAsTouched();
+    if (this.signupForm.invalid) {
+      return;
+    }
+
     const result = await this.api.signup(this.signupForm.getRawValue());
 
     if (result.error) {

--- a/src/app/services/user-supabase.service.ts
+++ b/src/app/services/user-supabase.service.ts
@@ -46,6 +46,34 @@ export class UserSupabaseService {
     });
   }
 
+  public async fetchUsernameExists(username: string): Promise<boolean> {
+    const { data, error } = await this.supabase
+      .from('user_data')
+      .select('username')
+      .eq('username', username);
+
+    if (error) {
+      console.error('Error fetching data:', error.message);
+      return false;
+    }
+
+    return data?.length !== 0;
+  }
+
+  public async fetchUserData(userId: string): Promise<UserData | null> {
+    const { data, error } = await this.supabase
+      .from('user_data')
+      .select('*')
+      .eq('user_id', userId);
+
+    if (error) {
+      console.error('Error fetching data:', error.message);
+      return null;
+    }
+
+    return data[0];
+  }
+
   public async fetchGamesCount(userId: string): Promise<number> {
     const { count, error } = await this.supabase
       .from('game')
@@ -80,3 +108,4 @@ export class UserSupabaseService {
     return countW + countB;
   }
 }
+type UserData = { username: string };

--- a/src/app/utilities/validation-funtions.ts
+++ b/src/app/utilities/validation-funtions.ts
@@ -3,19 +3,25 @@ import type {
   ValidationErrors,
   ValidatorFn,
 } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { inject } from '@angular/core';
 
 export function noWhitespace(): ValidatorFn {
+  const translateService = inject(TranslateService);
   return (control: AbstractControl): ValidationErrors | null => {
     const value: string | null = control.value;
     if (value === null) {
       return null;
     }
     const hasWhitespace = /\s/.test(value);
-    return hasWhitespace ? { whitespace: 'No whitespace allowed' } : null;
+    return hasWhitespace
+      ? { whitespace: translateService.instant('validationErrors.whitespace') }
+      : null;
   };
 }
 
-export function noUpperCaseLetters(): ValidatorFn {
+export function upperCasePresent(): ValidatorFn {
+  const translateService = inject(TranslateService);
   return (control: AbstractControl): ValidationErrors | null => {
     const value: string | null = control.value;
     if (value === null) {
@@ -23,12 +29,17 @@ export function noUpperCaseLetters(): ValidatorFn {
     }
     const noUpperCaseLetters = !/[A-Z]/.test(value);
     return noUpperCaseLetters
-      ? { noUpperCaseLetters: 'Field should include uppercase letters' }
+      ? {
+          noUpperCaseLetters: translateService.instant(
+            'validationErrors.noUpperCaseLetters',
+          ),
+        }
       : null;
   };
 }
 
-export function noLowerCaseLetters(): ValidatorFn {
+export function lowerCasePresent(): ValidatorFn {
+  const translateService = inject(TranslateService);
   return (control: AbstractControl): ValidationErrors | null => {
     const value: string | null = control.value;
     if (value === null) {
@@ -36,23 +47,31 @@ export function noLowerCaseLetters(): ValidatorFn {
     }
     const noLowerCaseLetters = !/[a-z]/.test(value);
     return noLowerCaseLetters
-      ? { noLowerCaseLetters: 'Field should include lowercase letters' }
+      ? {
+          noLowerCaseLetters: translateService.instant(
+            'validationErrors.noLowerCaseLetters',
+          ),
+        }
       : null;
   };
 }
 
-export function noNumbers(): ValidatorFn {
+export function numbersPresent(): ValidatorFn {
+  const translateService = inject(TranslateService);
   return (control: AbstractControl): ValidationErrors | null => {
     const value: string | null = control.value;
     if (value === null) {
       return null;
     }
     const noNumbers = !/[0-9]/.test(value);
-    return noNumbers ? { noNumbers: 'Field should include numbers' } : null;
+    return noNumbers
+      ? { noNumbers: translateService.instant('validationErrors.noNumbers') }
+      : null;
   };
 }
 
 export function noValidEmailFormat(): ValidatorFn {
+  const translateService = inject(TranslateService);
   return (control: AbstractControl): ValidationErrors | null => {
     const value: string | null = control.value;
     if (value === null) {
@@ -62,12 +81,37 @@ export function noValidEmailFormat(): ValidatorFn {
     const regex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
     const noPropperFormat = !regex.test(value);
     return noSymbol
-      ? { noSymbol: 'Email should include @' }
+      ? { noSymbol: translateService.instant('validationErrors.noSymbol') }
       : noPropperFormat
         ? {
-            noPropperFormat:
-              "Invalid email format, proper format is 'user@example.com'",
+            noPropperFormat: translateService.instant(
+              'validationErrors.noPropperFormat',
+            ),
           }
         : null;
+  };
+}
+
+export function createSamePasswordValidator(): ValidatorFn {
+  const translateService = inject(TranslateService);
+  return (form: AbstractControl): ValidationErrors | null => {
+    const password = form.get('password');
+    const confirmPassword = form.get('confirmPassword');
+
+    if (password?.value === confirmPassword?.value) {
+      confirmPassword?.setErrors(null);
+      return null;
+    } else {
+      confirmPassword?.setErrors({
+        passwordMismatch: translateService.instant(
+          'validationErrors.samePasswordValidator',
+        ),
+      });
+      return {
+        passwordMismatch: translateService.instant(
+          'validationErrors.samePasswordValidator',
+        ),
+      };
+    }
   };
 }


### PR DESCRIPTION
1. Title of changes: Add confirmation of password, errors translation
2. Type of change

- [X] Bug fix
- [X] New feature
- [ ] Documentation update

3. Title and number of issues: Подтверждение пароля на странице sign-up
[#37](https://github.com/sorcerers-apprentices/chess/issues/37)
4. Screenshots: 
<img width="708" height="652" alt="Screenshot 2025-09-13 at 22 54 11" src="https://github.com/user-attachments/assets/5befab45-20fa-41d0-b716-298b412df4e7" />

5. Description:  Добавила поле подтверждение пароля на поле регистрации. Добавила отдельную кастомную валидацию для него. Функция валидации принимает form: AbstractControl, из которой берём значение пароля и справниваем. Добавила перевод для этих ошибок (сложноа-то было с переводом ошибок у тайги). Перемесила гарды в отдельный файл. Исправила размер шрифта в sign-up-page, чтобы не съезжал так текст криво.
6. Important notices for future work: Пока не двигаю таски с юзерсторем и роутингом. Разберусь с асинхронной валидацией юзер нейма и закрою их
