### PR TITLE
Change color dark theme

### DIFF
--- a/src/app/constants/chess-square.constans.ts
+++ b/src/app/constants/chess-square.constans.ts
@@ -10,7 +10,7 @@ import { FILES, RANKS } from '@/app/types/chess-square.type';
 export const RANKS_TOP_DOWN = [...RANKS].reverse();
 
 export const LIGHT: ColorLightType = 'var(--tui-chart-categorical-18)';
-export const DARK: ColorDarkType = 'var(--tui-background-accent-3)';
+export const DARK: ColorDarkType = 'var(--tui-background-elevation-3)';
 
 /** Готовые 64 клетки с цветами */
 export const SQUARE_STATES: readonly SquareStateType[] =

--- a/src/app/pages/game-page/game-page.scss
+++ b/src/app/pages/game-page/game-page.scss
@@ -23,6 +23,10 @@
   background-color: var(--tui-background-neutral-2-pressed);
 }
 
+.player-panel {
+  background-color: var(--tui-background-neutral-2-pressed);
+}
+
 .game-board {
   display: flex;
   flex-direction: column;

--- a/src/app/types/chess-square.type.ts
+++ b/src/app/types/chess-square.type.ts
@@ -16,7 +16,7 @@ export type PieceType = {
 export type PieceColorType = 'white' | 'black';
 
 export type ColorLightType = 'var(--tui-chart-categorical-18)';
-export type ColorDarkType = 'var(--tui-background-accent-3)';
+export type ColorDarkType = 'var(--tui-background-elevation-3)';
 export type SquareColorType = ColorLightType | ColorDarkType;
 
 export type PieceKindType =


### PR DESCRIPTION
1. Title of changes: Visual representation of a chessboard on a dark theme
2. Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

3. Title and number of issues: [#49](https://github.com/sorcerers-apprentices/chess/issues/49)
4. Screenshots: 
<img width="1560" height="1212" alt="image" src="https://github.com/user-attachments/assets/58c6299d-a52f-4f4b-8d3c-3fce9c8b4d27" />

5. Description: Visual representation of a chessboard on a dark theme
6. Important notices for future work:
