### PR TITLE
Drag&Drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^20.2.4",
+        "@angular/cdk": "^20.2.3",
         "@angular/common": "20.2.4",
         "@angular/compiler": "20.2.4",
         "@angular/core": "20.2.4",
@@ -640,11 +641,10 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.2.2.tgz",
-      "integrity": "sha512-jLvIMmFI8zoi6vAu1Aszua59GmhqBOtsVfkwLUGg5Hi86DI/inJr9BznNX2EKDtaulYMGZCmDgsltXQXeqP5Lg==",
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.2.3.tgz",
+      "integrity": "sha512-gu1zzxxcwobeiH21VpphM+cPFrQX0dxGwlFx1W8eTcLYLWd9YjlTETucBrEUEWcXmRrVTXf/VcqA0rWsxd50Ow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@angular/animations": "^20.2.4",
+    "@angular/cdk": "^20.2.3",
     "@angular/common": "20.2.4",
     "@angular/compiler": "20.2.4",
     "@angular/core": "20.2.4",

--- a/src/app/components/chess-board/chess-board.html
+++ b/src/app/components/chess-board/chess-board.html
@@ -5,7 +5,7 @@
     }
   </div>
 
-  <div class="board">
+  <div cdkDropListGroup class="board">
     @for (square of squares(); track square.square) {
       <app-chess-square
         [square]="square.square"
@@ -15,6 +15,10 @@
         [isOverAllowed]="square.isOverAllowed"
         [isOverDenied]="square.isOverDenied"
         (chessMove)="onSquareMove($event)"
+        (dragStartSquare)="onDragStart($event)"
+        (dragEnterSquare)="onDragEnter($event)"
+        (dragEndSquare)="onDragEnd()"
+        [allSquares]="allSquareIds()"
       />
     }
   </div>

--- a/src/app/components/chess-board/chess-board.html
+++ b/src/app/components/chess-board/chess-board.html
@@ -11,6 +11,10 @@
         [square]="square.square"
         [backgroundColor]="square.squareColor"
         [piece]="square.piece"
+        [isFrom]="square.isFrom"
+        [isOverAllowed]="square.isOverAllowed"
+        [isOverDenied]="square.isOverDenied"
+        (chessMove)="onSquareMove($event)"
       />
     }
   </div>

--- a/src/app/components/chess-board/chess-board.ts
+++ b/src/app/components/chess-board/chess-board.ts
@@ -29,36 +29,43 @@ import { CdkDropListGroup } from '@angular/cdk/drag-drop';
 })
 export class ChessBoard {
   public readonly orientation = input.required<BoardOrientationType>();
+  // emit event наверх, один раз на «успешный» DnD-ход: { from, to }.
   public readonly move = output<ChessMovePayloadType>();
 
+  // emit event наверх, user начал перетаскивание фигуры с клетки
   public readonly dragStart = output<SquareType>();
+  // emit event наверх, перетаскивание завершено (не важно, был drop или отмена)
   public readonly dragEnd = output<void>();
 
+  // Массив файлов (a…h) для подписи оси X.
   protected readonly files = FILES;
+  // Массив рангов (8…1) для подписи оси Y в «верх-вниз».
   protected readonly ranks = RANKS_TOP_DOWN;
 
   protected readonly boardStateUI = inject(BoardStateService);
 
-  // 🔹 Добавляем локальный сигнал: пока null (поведение как у тебя сейчас)
+  // Добавляем локальный сигнал: пока null
   protected readonly allowedTargets = signal<ReadonlySet<SquareType> | null>(
     null,
   );
 
-  protected readonly allSquareIds = computed(
-    () => this.squares().map((s) => s.square), // ['a1', 'b1', ..., 'h8']
+  //список id клеток в текущей разметке передается в клетку
+  protected readonly allSquareIds = computed(() =>
+    this.squares().map((s) => s.square),
   );
 
-  /** Сигнал с клетками для отрисовки */
+  /** Сигнал с клетками для отрисовки - источник правды для шаблона по клеткам. На вход берёт три сигнала*/
   protected readonly squares = computed<readonly SquareUiStateType[]>(() => {
     const from = this.dragFrom();
     const over = this.dragOver();
-    const allow = this.allowedTargets();
+    const allow = this.allowedTargets(); // разрешённые цели (или null).
 
+    //мапит базовое состояние из boardStateUI.squares() и рассчитывает три флага подсветки
     return this.boardStateUI.squares().map((s) => {
       const isFrom = from === s.square;
       const isOver = over === s.square;
 
-      // 🔹 единое правило: если allow=null → как раньше (разрешено всё, кроме from)
+      // единое правило: если allow=null → как раньше (разрешено всё, кроме from)
       const canDropHere =
         from !== null &&
         s.square !== from &&
@@ -67,12 +74,15 @@ export class ChessBoard {
       const isOverAllowed = isOver && canDropHere;
       const isOverDenied = isOver && !canDropHere;
 
+      // возвращаем расширенный SquareUiStateType с флагами подсветок
       return { ...s, isFrom, isOverAllowed, isOverDenied };
     });
   });
 
   // подсветка DnD
+  //Какая клетка стала источником DnD (когда подняли фигуру). null — ничего не тянем
   private readonly dragFrom = signal<SquareType | null>(null);
+  // Какую клетку сейчас подсвечиваем по ходу DnD.
   private readonly dragOver = signal<SquareType | null>(null);
 
   constructor() {
@@ -98,16 +108,17 @@ export class ChessBoard {
     this.dragEnd.emit();
   }
 
-  protected onSquareMove = (e: ChessMovePayloadType): void => {
+  //клетка-цель сгенерировала итог события «фигура упала ко мне», и прислала payload { from, to }
+  protected onSquareMove = (payload: ChessMovePayloadType): void => {
     // пока лог и сброс подсветки
-    console.log('[ChessBoard] DND move payload', e);
+    console.log('[ChessBoard] DND move payload', payload);
 
     this.dragFrom.set(null);
     this.dragOver.set(null);
 
-    // диспатч хода в BoardStateService
-    this.boardStateUI.movePiece(e);
+    // применяем ход к UI-состоянию (фигуры на доске реально переезжают в сервисе)
+    this.boardStateUI.movePiece(payload);
 
-    this.move.emit(e);
+    this.move.emit(payload);
   };
 }

--- a/src/app/components/chess-board/chess-board.ts
+++ b/src/app/components/chess-board/chess-board.ts
@@ -110,9 +110,6 @@ export class ChessBoard {
 
   //клетка-цель сгенерировала итог события «фигура упала ко мне», и прислала payload { from, to }
   protected onSquareMove = (payload: ChessMovePayloadType): void => {
-    // пока лог и сброс подсветки
-    console.log('[ChessBoard] DND move payload', payload);
-
     this.dragFrom.set(null);
     this.dragOver.set(null);
 

--- a/src/app/components/chess-board/chess-board.ts
+++ b/src/app/components/chess-board/chess-board.ts
@@ -4,12 +4,19 @@ import {
   computed,
   inject,
   input,
+  output,
+  signal,
 } from '@angular/core';
+import type {
+  SquareType,
+  SquareUiStateType,
+} from '@/app/types/chess-square.type';
 import { FILES } from '@/app/types/chess-square.type';
 import { RANKS_TOP_DOWN } from '@/app/constants/chess-square.constans';
 import { ChessSquare } from '@/app/components/chess-square/chess-square';
 import { BoardSetupService } from '@/app/services/board-setup.service';
 import type { BoardOrientationType } from '@/app/types/chess-piece.type';
+import type { ChessMovePayloadType } from '@/app/types/drag-drop-data.type';
 
 @Component({
   selector: 'app-chess-board',
@@ -20,10 +27,38 @@ import type { BoardOrientationType } from '@/app/types/chess-piece.type';
 })
 export class ChessBoard {
   public readonly orientation = input.required<BoardOrientationType>();
+  public readonly move = output<ChessMovePayloadType>();
+
   protected readonly files = FILES;
   protected readonly ranks = RANKS_TOP_DOWN;
   protected readonly boardSetup = inject(BoardSetupService);
-  protected readonly squares = computed(() =>
+  protected readonly baseSquares = computed(() =>
     this.boardSetup.createInitialSquares(this.orientation()),
   );
+
+  protected readonly squares = computed<readonly SquareUiStateType[]>(() =>
+    this.baseSquares().map((s) => {
+      const from = this.dragFrom();
+      const over = this.dragOver();
+
+      const isFrom = from === s.square;
+      const isOver = over === s.square;
+      const isOverAllowed = isOver && from !== s.square && from !== null;
+      const isOverDenied = isOver && from === s.square;
+
+      return { ...s, isFrom, isOverAllowed, isOverDenied };
+    }),
+  );
+
+  // подсветка DnD
+  private readonly dragFrom = signal<SquareType | null>(null);
+  private readonly dragOver = signal<SquareType | null>(null);
+
+  protected onSquareMove = (e: ChessMovePayloadType): void => {
+    // пока лог и сброс подсветки
+    console.log('DND move:', e);
+    this.dragFrom.set(null);
+    this.dragOver.set(null);
+    this.move.emit(e);
+  };
 }

--- a/src/app/components/chess-board/chess-board.ts
+++ b/src/app/components/chess-board/chess-board.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   input,
   output,
@@ -14,13 +15,14 @@ import type {
 import { FILES } from '@/app/types/chess-square.type';
 import { RANKS_TOP_DOWN } from '@/app/constants/chess-square.constans';
 import { ChessSquare } from '@/app/components/chess-square/chess-square';
-import { BoardSetupService } from '@/app/services/board-setup.service';
 import type { BoardOrientationType } from '@/app/types/chess-piece.type';
 import type { ChessMovePayloadType } from '@/app/types/drag-drop-data.type';
+import { BoardStateService } from '@/app/services/board-state.service';
+import { CdkDropListGroup } from '@angular/cdk/drag-drop';
 
 @Component({
   selector: 'app-chess-board',
-  imports: [ChessSquare],
+  imports: [ChessSquare, ChessSquare, CdkDropListGroup],
   templateUrl: './chess-board.html',
   styleUrl: './chess-board.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -29,36 +31,83 @@ export class ChessBoard {
   public readonly orientation = input.required<BoardOrientationType>();
   public readonly move = output<ChessMovePayloadType>();
 
+  public readonly dragStart = output<SquareType>();
+  public readonly dragEnd = output<void>();
+
   protected readonly files = FILES;
   protected readonly ranks = RANKS_TOP_DOWN;
-  protected readonly boardSetup = inject(BoardSetupService);
-  protected readonly baseSquares = computed(() =>
-    this.boardSetup.createInitialSquares(this.orientation()),
+
+  protected readonly boardStateUI = inject(BoardStateService);
+
+  // 🔹 Добавляем локальный сигнал: пока null (поведение как у тебя сейчас)
+  protected readonly allowedTargets = signal<ReadonlySet<SquareType> | null>(
+    null,
   );
 
-  protected readonly squares = computed<readonly SquareUiStateType[]>(() =>
-    this.baseSquares().map((s) => {
-      const from = this.dragFrom();
-      const over = this.dragOver();
+  protected readonly allSquareIds = computed(
+    () => this.squares().map((s) => s.square), // ['a1', 'b1', ..., 'h8']
+  );
 
+  /** Сигнал с клетками для отрисовки */
+  protected readonly squares = computed<readonly SquareUiStateType[]>(() => {
+    const from = this.dragFrom();
+    const over = this.dragOver();
+    const allow = this.allowedTargets();
+
+    return this.boardStateUI.squares().map((s) => {
       const isFrom = from === s.square;
       const isOver = over === s.square;
-      const isOverAllowed = isOver && from !== s.square && from !== null;
-      const isOverDenied = isOver && from === s.square;
+
+      // 🔹 единое правило: если allow=null → как раньше (разрешено всё, кроме from)
+      const canDropHere =
+        from !== null &&
+        s.square !== from &&
+        (allow ? allow.has(s.square) : true);
+
+      const isOverAllowed = isOver && canDropHere;
+      const isOverDenied = isOver && !canDropHere;
 
       return { ...s, isFrom, isOverAllowed, isOverDenied };
-    }),
-  );
+    });
+  });
 
   // подсветка DnD
   private readonly dragFrom = signal<SquareType | null>(null);
   private readonly dragOver = signal<SquareType | null>(null);
 
-  protected onSquareMove = (e: ChessMovePayloadType): void => {
-    // пока лог и сброс подсветки
-    console.log('DND move:', e);
+  constructor() {
+    // инициализация доски при изменении ориентации
+    effect(() => {
+      this.boardStateUI.init(this.orientation());
+    });
+  }
+
+  public onDragStart(square: SquareType): void {
+    this.dragFrom.set(square);
+    this.dragOver.set(null);
+    this.dragStart.emit(square);
+  }
+
+  public onDragEnter(square: SquareType): void {
+    this.dragOver.set(square);
+  }
+
+  public onDragEnd(): void {
     this.dragFrom.set(null);
     this.dragOver.set(null);
+    this.dragEnd.emit();
+  }
+
+  protected onSquareMove = (e: ChessMovePayloadType): void => {
+    // пока лог и сброс подсветки
+    console.log('[ChessBoard] DND move payload', e);
+
+    this.dragFrom.set(null);
+    this.dragOver.set(null);
+
+    // диспатч хода в BoardStateService
+    this.boardStateUI.movePiece(e);
+
     this.move.emit(e);
   };
 }

--- a/src/app/components/chess-square/chess-square.html
+++ b/src/app/components/chess-square/chess-square.html
@@ -1,19 +1,24 @@
 <div
+  cdkDropList
+  [cdkDropListData]="dropData()"
+  (cdkDropListEntered)="handleDragEnter()"
+  [cdkDropListEnterPredicate]="canEnter"
+  (cdkDropListDropped)="onDrop($event)"
+  [cdkDropListConnectedTo]="connectedToIds()"
+  [style.background-color]="backgroundColor()"
+  [id]="square()"
+  [attr.data-square]="square()"
   class="square"
   [class.is-from]="isFrom()"
   [class.is-over-allowed]="isOverAllowed()"
   [class.is-over-denied]="isOverDenied()"
-  cdkDropList
-  [cdkDropListData]="dropData()"
-  [cdkDropListEnterPredicate]="canEnter"
-  (cdkDropListDropped)="onDrop($event)"
-  [style.background-color]="backgroundColor()"
-  [attr.data-square]="square()"
   [class.is-empty]="!hasPiece()"
 >
   <img
     cdkDrag
     [cdkDragData]="dragData()"
+    (cdkDragStarted)="handleDragStart()"
+    (cdkDragEnded)="handleDragEnd()"
     draggable="false"
     class="piece"
     [src]="icon()"

--- a/src/app/components/chess-square/chess-square.html
+++ b/src/app/components/chess-square/chess-square.html
@@ -1,8 +1,22 @@
 <div
   class="square"
+  [class.is-from]="isFrom()"
+  [class.is-over-allowed]="isOverAllowed()"
+  [class.is-over-denied]="isOverDenied()"
+  cdkDropList
+  [cdkDropListData]="dropData()"
+  [cdkDropListEnterPredicate]="canEnter"
+  (cdkDropListDropped)="onDrop($event)"
   [style.background-color]="backgroundColor()"
   [attr.data-square]="square()"
   [class.is-empty]="!hasPiece()"
 >
-  <img class="piece" [src]="icon()" [alt]="altText()" />
+  <img
+    cdkDrag
+    [cdkDragData]="dragData()"
+    draggable="false"
+    class="piece"
+    [src]="icon()"
+    [alt]="altText()"
+  />
 </div>

--- a/src/app/components/chess-square/chess-square.html
+++ b/src/app/components/chess-square/chess-square.html
@@ -3,9 +3,9 @@
   [cdkDropListData]="dropData()"
   (cdkDropListEntered)="handleDragEnter()"
   [cdkDropListEnterPredicate]="canEnter"
-  cdkDropListSortingDisabled
   (cdkDropListDropped)="onDrop($event)"
   [cdkDropListConnectedTo]="connectedToIds()"
+  cdkDropListSortingDisabled
   [style.background-color]="backgroundColor()"
   [id]="square()"
   [attr.data-square]="square()"

--- a/src/app/components/chess-square/chess-square.html
+++ b/src/app/components/chess-square/chess-square.html
@@ -3,6 +3,7 @@
   [cdkDropListData]="dropData()"
   (cdkDropListEntered)="handleDragEnter()"
   [cdkDropListEnterPredicate]="canEnter"
+  cdkDropListSortingDisabled
   (cdkDropListDropped)="onDrop($event)"
   [cdkDropListConnectedTo]="connectedToIds()"
   [style.background-color]="backgroundColor()"
@@ -24,4 +25,5 @@
     [src]="icon()"
     [alt]="altText()"
   />
+  <ng-template cdkDragPlaceholder></ng-template>
 </div>

--- a/src/app/components/chess-square/chess-square.scss
+++ b/src/app/components/chess-square/chess-square.scss
@@ -1,3 +1,5 @@
+@use "variables" as vars;
+
 .square {
   display: flex;
   align-items: center;
@@ -5,6 +7,26 @@
   width: 100%;
   height: 100%;
   font-size: 20px;
+
+  // состояние: откуда тащим
+  &.is-from {
+    outline: 3px solid var(--tui-background-accent-1);
+    outline-offset: -3px;
+  }
+
+  // состояние: можно бросить
+  &.is-over-allowed {
+    z-index: 1;
+    outline: 4px solid var(--tui-status-positive);
+    outline-offset: -4px;
+  }
+
+  // состояние: бросить нельзя
+  &.is-over-denied {
+    z-index: 1;
+    outline: 4px solid vars.$color-red2;
+    outline-offset: -4px;
+  }
 }
 
 .piece {
@@ -17,4 +39,12 @@
 
 .is-empty .piece {
   display: none; // фигура скрыта, если её нет
+}
+
+.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.square.is-over-allowed .piece {
+  opacity: 0;
 }

--- a/src/app/components/chess-square/chess-square.ts
+++ b/src/app/components/chess-square/chess-square.ts
@@ -97,15 +97,12 @@ export class ChessSquare {
 
   // хендлеры без логики
   public handleDragStart(): void {
-    console.log('[ChessSquare] dragStart', this.square());
     this.dragStartSquare.emit(this.square());
   }
   public handleDragEnter(): void {
-    console.log('[ChessSquare] dragEnter', this.square());
     this.dragEnterSquare.emit(this.square());
   }
   public handleDragEnd(): void {
-    console.log('[ChessSquare] dragEnd', this.square());
     this.dragEndSquare.emit();
   }
 
@@ -124,26 +121,12 @@ export class ChessSquare {
       // запрещаем вход на свою фигуру
       (!dropData.piece || dropData.piece.color !== dragData.piece.color);
 
-    console.log(
-      '[ChessSquare] canEnter? from=',
-      isDragData(dragData) ? dragData.fromSquare : 'X',
-      'to=',
-      isDropData(dropData) ? dropData.square : 'X',
-      '=>',
-      isAllowed,
-    );
-
     return isAllowed;
   };
 
   public onDrop(
     event: CdkDragDrop<DropDataType, DropDataType, DragDataType>,
   ): void {
-    console.log('[ChessSquare] onDrop', {
-      from: event.item?.data,
-      to: event.container?.data,
-    });
-
     const dragged = event.item?.data;
     const target = event.container?.data;
 

--- a/src/app/components/chess-square/chess-square.ts
+++ b/src/app/components/chess-square/chess-square.ts
@@ -14,6 +14,7 @@ import type {
 
 import { PIECE_ICON_URL } from '@/app/constants/chess-piece.constans';
 import type { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { CdkDragPlaceholder } from '@angular/cdk/drag-drop';
 import { CdkDrag, CdkDropList } from '@angular/cdk/drag-drop';
 import type {
   ChessMovePayloadType,
@@ -24,56 +25,77 @@ import { isDragData, isDropData } from '@/app/utilities/chess-piece';
 
 @Component({
   selector: 'app-chess-square',
-  imports: [CdkDropList, CdkDrag],
+  imports: [CdkDropList, CdkDrag, CdkDragPlaceholder],
   templateUrl: './chess-square.html',
   styleUrl: './chess-square.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ChessSquare {
+  // координата клетки (id)
   public readonly square = input.required<SquareType>();
+  //фон клетки
   public readonly backgroundColor = input.required<SquareColorType>();
+  // объект фигуры в клетке (id, цвет, что за фигура)
   public readonly piece = input<PieceType | null>(null);
+  //event попытка хода drop: { from, to }
   public readonly chessMove = output<ChessMovePayloadType>();
 
   // флаги подсветки — придут от родителя
+  // источник перетягивания
   public readonly isFrom = input<boolean>(false);
+  //курсор/фигура «над этой клеткой, ход разрешён».
   public readonly isOverAllowed = input<boolean>(false);
+  // курсор/фигура «над этой клеткой, ход запрещён».
   public readonly isOverDenied = input<boolean>(false);
+
   // добавляем события для родителя
+  // старт с этой клетки а4 h5
   public readonly dragStartSquare = output<SquareType>();
+  // перешли на эту клетку
   public readonly dragEnterSquare = output<SquareType>();
+  // поставили (успешно или отменили)
   public readonly dragEndSquare = output<void>();
 
+  // Список всех клеток доски (координат) чтобы сконфигурировать «с кем связана» текущая cdkDropList (клетка)
   public readonly allSquares = input.required<readonly SquareType[]>();
 
+  // От фигуры → к URL иконки: PIECE_ICON_URL[kind][color] или пустая строка, если фигуры нет. Идёт в <img [src]>
   protected readonly icon: Signal<string> = computed(() => {
-    const p = this.piece();
-    return p ? PIECE_ICON_URL[p.kind][p.color] : '';
+    const pieceIcon = this.piece();
+    return pieceIcon ? PIECE_ICON_URL[pieceIcon.kind][pieceIcon.color] : '';
   });
 
+  //Массив «подключённых» DropList (все клетки кроме себя). Используется в шаблоне на cdkDropListConnectedTo
+  //Это позволяет ввозить/вывозить drag в любую другую клетку.
   protected readonly connectedToIds = computed(() =>
     this.allSquares().filter((id) => id !== this.square()),
   );
 
+  // Альт-текст для иконки фигуры
   protected readonly altText = computed(() => {
-    const p = this.piece();
-    return p ? `${p.color} ${p.kind}` : '';
+    const pieceAltText = this.piece();
+    return pieceAltText ? `${pieceAltText.color} ${pieceAltText.kind}` : '';
   });
 
+  // Флаг «в клетке есть фигура»
   protected readonly hasPiece = computed(() => this.piece() !== null);
 
+  // Данные, которые CDK будет «таскать»: { piece, fromSquare } или null, если нечего тащить.
+  //DragDataType Что тащим (источник)
   protected readonly dragData: Signal<DragDataType | null> =
     computed<DragDataType | null>(() => {
       const pieceDrag = this.piece();
       return pieceDrag ? { piece: pieceDrag, fromSquare: this.square() } : null;
     });
 
+  // Данные целевой DropList: куда бросаем (клетка square) и кто там сейчас лежит (piece | null).
+  // DropDataType Куда бросаем (цель)
   protected readonly dropData = computed<DropDataType>(() => ({
     square: this.square(),
     piece: this.piece(),
   }));
 
-  // тонкие хендлеры без логики
+  // хендлеры без логики
   public handleDragStart(): void {
     console.log('[ChessSquare] dragStart', this.square());
     this.dragStartSquare.emit(this.square());
@@ -87,6 +109,7 @@ export class ChessSquare {
     this.dragEndSquare.emit();
   }
 
+  // функция-предикат для cdkDropListEnterPredicate. Она решает: пускать ли текущий Drag в эту DropList.
   public readonly canEnter = (
     drag: CdkDrag<DragDataType>,
     drop: CdkDropList<DropDataType>,

--- a/src/app/components/chess-square/chess-square.ts
+++ b/src/app/components/chess-square/chess-square.ts
@@ -1,4 +1,5 @@
 import type { Signal } from '@angular/core';
+import { output } from '@angular/core';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -12,10 +13,18 @@ import type {
 } from '@/app/types/chess-square.type';
 
 import { PIECE_ICON_URL } from '@/app/constants/chess-piece.constans';
+import type { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { CdkDrag, CdkDropList } from '@angular/cdk/drag-drop';
+import type {
+  ChessMovePayloadType,
+  DragDataType,
+  DropDataType,
+} from '@/app/types/drag-drop-data.type';
+import { isDragData, isDropData } from '@/app/utilities/chess-piece';
 
 @Component({
   selector: 'app-chess-square',
-  imports: [],
+  imports: [CdkDropList, CdkDrag],
   templateUrl: './chess-square.html',
   styleUrl: './chess-square.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -24,6 +33,12 @@ export class ChessSquare {
   public readonly square = input.required<SquareType>();
   public readonly backgroundColor = input.required<SquareColorType>();
   public readonly piece = input<PieceType | null>(null);
+  public readonly chessMove = output<ChessMovePayloadType>();
+
+  // флаги подсветки — придут от родителя
+  public readonly isFrom = input<boolean>(false);
+  public readonly isOverAllowed = input<boolean>(false);
+  public readonly isOverDenied = input<boolean>(false);
 
   protected readonly icon: Signal<string> = computed(() => {
     const p = this.piece();
@@ -36,4 +51,44 @@ export class ChessSquare {
   });
 
   protected readonly hasPiece = computed(() => this.piece() !== null);
+
+  protected readonly dragData: Signal<DragDataType | null> =
+    computed<DragDataType | null>(() => {
+      const pieceDrag = this.piece();
+      return pieceDrag ? { piece: pieceDrag, fromSquare: this.square() } : null;
+    });
+
+  protected readonly dropData = computed<DropDataType>(() => ({
+    square: this.square(),
+    piece: this.piece(),
+  }));
+
+  public readonly canEnter = (
+    drag: CdkDrag<DragDataType>,
+    drop: CdkDropList<DropDataType>,
+  ): boolean => {
+    const dragData = drag.data;
+    const dropData = drop.data;
+
+    if (!isDragData(dragData) || !isDropData(dropData)) return false;
+
+    // запрет "дропа в ту же клетку"
+    return dragData.fromSquare !== dropData.square;
+  };
+
+  public onDrop(
+    event: CdkDragDrop<DropDataType, DropDataType, DragDataType>,
+  ): void {
+    const dragged = event.item?.data;
+    const target = event.container?.data;
+
+    if (!isDragData(dragged) || !isDropData(target)) return;
+
+    // игнор, если бросили в ту же клетку
+    if (dragged.fromSquare === target.square) return;
+
+    // тут НЕТ шахматной валидации — только событие UX.
+    // шахматные правила пусть проверяет родитель/сервис с chess.js.
+    this.chessMove.emit({ from: dragged.fromSquare, to: target.square });
+  }
 }

--- a/src/app/components/chess-square/chess-square.ts
+++ b/src/app/components/chess-square/chess-square.ts
@@ -39,11 +39,21 @@ export class ChessSquare {
   public readonly isFrom = input<boolean>(false);
   public readonly isOverAllowed = input<boolean>(false);
   public readonly isOverDenied = input<boolean>(false);
+  // добавляем события для родителя
+  public readonly dragStartSquare = output<SquareType>();
+  public readonly dragEnterSquare = output<SquareType>();
+  public readonly dragEndSquare = output<void>();
+
+  public readonly allSquares = input.required<readonly SquareType[]>();
 
   protected readonly icon: Signal<string> = computed(() => {
     const p = this.piece();
     return p ? PIECE_ICON_URL[p.kind][p.color] : '';
   });
+
+  protected readonly connectedToIds = computed(() =>
+    this.allSquares().filter((id) => id !== this.square()),
+  );
 
   protected readonly altText = computed(() => {
     const p = this.piece();
@@ -63,6 +73,20 @@ export class ChessSquare {
     piece: this.piece(),
   }));
 
+  // тонкие хендлеры без логики
+  public handleDragStart(): void {
+    console.log('[ChessSquare] dragStart', this.square());
+    this.dragStartSquare.emit(this.square());
+  }
+  public handleDragEnter(): void {
+    console.log('[ChessSquare] dragEnter', this.square());
+    this.dragEnterSquare.emit(this.square());
+  }
+  public handleDragEnd(): void {
+    console.log('[ChessSquare] dragEnd', this.square());
+    this.dragEndSquare.emit();
+  }
+
   public readonly canEnter = (
     drag: CdkDrag<DragDataType>,
     drop: CdkDropList<DropDataType>,
@@ -70,15 +94,31 @@ export class ChessSquare {
     const dragData = drag.data;
     const dropData = drop.data;
 
-    if (!isDragData(dragData) || !isDropData(dropData)) return false;
+    const isAllowed =
+      isDragData(dragData) &&
+      isDropData(dropData) &&
+      dragData.fromSquare !== dropData.square;
 
-    // запрет "дропа в ту же клетку"
-    return dragData.fromSquare !== dropData.square;
+    console.log(
+      '[ChessSquare] canEnter? from=',
+      isDragData(dragData) ? dragData.fromSquare : 'X',
+      'to=',
+      isDropData(dropData) ? dropData.square : 'X',
+      '=>',
+      isAllowed,
+    );
+
+    return isAllowed;
   };
 
   public onDrop(
     event: CdkDragDrop<DropDataType, DropDataType, DragDataType>,
   ): void {
+    console.log('[ChessSquare] onDrop', {
+      from: event.item?.data,
+      to: event.container?.data,
+    });
+
     const dragged = event.item?.data;
     const target = event.container?.data;
 

--- a/src/app/components/chess-square/chess-square.ts
+++ b/src/app/components/chess-square/chess-square.ts
@@ -120,7 +120,9 @@ export class ChessSquare {
     const isAllowed =
       isDragData(dragData) &&
       isDropData(dropData) &&
-      dragData.fromSquare !== dropData.square;
+      dragData.fromSquare !== dropData.square &&
+      // запрещаем вход на свою фигуру
+      (!dropData.piece || dropData.piece.color !== dragData.piece.color);
 
     console.log(
       '[ChessSquare] canEnter? from=',

--- a/src/app/constants/chess-square.constans.ts
+++ b/src/app/constants/chess-square.constans.ts
@@ -1,16 +1,16 @@
 import type {
-  ColorDarkType,
-  ColorLightType,
   SquareType,
   SquareColorType,
   SquareStateType,
+  ColorWhiteType,
+  ColorBlackType,
 } from '@/app/types/chess-square.type';
 import { FILES, RANKS } from '@/app/types/chess-square.type';
 
 export const RANKS_TOP_DOWN = [...RANKS].reverse();
 
-export const LIGHT: ColorLightType = 'var(--tui-chart-categorical-18)';
-export const DARK: ColorDarkType = 'var(--tui-background-elevation-3)';
+export const LIGHT: ColorWhiteType = 'var(--tui-chart-categorical-18)';
+export const DARK: ColorBlackType = 'var(--tui-background-elevation-3)';
 
 /** Готовые 64 клетки с цветами */
 export const SQUARE_STATES: readonly SquareStateType[] =

--- a/src/app/pages/game-page/game-page.html
+++ b/src/app/pages/game-page/game-page.html
@@ -7,7 +7,12 @@
       <div class="player-panel top">
         <app-player-panel [color]="topPlayerColor" />
       </div>
-      <app-chess-board [orientation]="orientation" />
+      <app-chess-board
+        (move)="onBoardMove($event)"
+        (dragStart)="onBoardDragStart($event)"
+        (dragEnd)="onBoardDragEnd()"
+        [orientation]="orientation"
+      />
       <div class="player-panel bottom">
         <app-player-panel [color]="bottomPlayerColor" />
       </div>

--- a/src/app/pages/game-page/game-page.ts
+++ b/src/app/pages/game-page/game-page.ts
@@ -32,7 +32,7 @@ export class GamePage {
   protected readonly bottomPlayerColor: 'white' | 'black' =
     this.orientation === 'whiteBottom' ? 'white' : 'black';
 
-  // последний совершённый ход (для логов/истории/нотации — по желанию)
+  // последний совершённый ход (для логов/истории/нотации)
   protected readonly lastMove = signal<ChessMovePayloadType | null>(null);
 
   // локально можем хранить, откуда началось перетаскивание (если нужно для UI страницы)
@@ -40,18 +40,18 @@ export class GamePage {
 
   public onBoardDragStart(from: SquareType): void {
     this.dragFrom.set(from);
-    // здесь позже (когда будет движок) посчитаешь allowedTargets и пробросишь в Board
+    // здесь когда будет движок посчитать allowedTargets и пробросить в Board
   }
 
   public onBoardDragEnd(): void {
     this.dragFrom.set(null);
-    // здесь позже очистишь allowedTargets
+    // здесь позже очистить allowedTargets
   }
 
-  public onBoardMove(e: ChessMovePayloadType): void {
-    this.lastMove.set(e);
-    // здесь позже дергаешь движок/сервис, таймеры, историю и т.д.
-    // сейчас можно просто логировать:
-    console.log('[GamePage] move', e);
+  public onBoardMove(event: ChessMovePayloadType): void {
+    this.lastMove.set(event);
+    // здесь позже дергать движок/сервис, таймеры, историю и т.д.
+    // сейчас просто логировать:
+    console.log('[GamePage] move', event);
   }
 }

--- a/src/app/pages/game-page/game-page.ts
+++ b/src/app/pages/game-page/game-page.ts
@@ -1,11 +1,13 @@
 import { Header } from '../../components/header/header';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { TuiNavigation } from '@taiga-ui/layout';
 import { Navigation } from '../../components/navigation/navigation';
 import { ChessBoard } from '@/app/components/chess-board/chess-board';
 import { GameSettings } from '@/app/components/game-settings/game-settings';
 import { PlayerPanel } from '@/app/components/player-panel/player-panel';
 import type { BoardOrientationType } from '@/app/types/chess-piece.type';
+import type { SquareType } from '@/app/types/chess-square.type';
+import type { ChessMovePayloadType } from '@/app/types/drag-drop-data.type';
 
 @Component({
   selector: 'app-game-page',
@@ -29,4 +31,27 @@ export class GamePage {
 
   protected readonly bottomPlayerColor: 'white' | 'black' =
     this.orientation === 'whiteBottom' ? 'white' : 'black';
+
+  // последний совершённый ход (для логов/истории/нотации — по желанию)
+  protected readonly lastMove = signal<ChessMovePayloadType | null>(null);
+
+  // локально можем хранить, откуда началось перетаскивание (если нужно для UI страницы)
+  private readonly dragFrom = signal<SquareType | null>(null);
+
+  public onBoardDragStart(from: SquareType): void {
+    this.dragFrom.set(from);
+    // здесь позже (когда будет движок) посчитаешь allowedTargets и пробросишь в Board
+  }
+
+  public onBoardDragEnd(): void {
+    this.dragFrom.set(null);
+    // здесь позже очистишь allowedTargets
+  }
+
+  public onBoardMove(e: ChessMovePayloadType): void {
+    this.lastMove.set(e);
+    // здесь позже дергаешь движок/сервис, таймеры, историю и т.д.
+    // сейчас можно просто логировать:
+    console.log('[GamePage] move', e);
+  }
 }

--- a/src/app/pages/game-page/game-page.ts
+++ b/src/app/pages/game-page/game-page.ts
@@ -51,7 +51,5 @@ export class GamePage {
   public onBoardMove(event: ChessMovePayloadType): void {
     this.lastMove.set(event);
     // здесь позже дергать движок/сервис, таймеры, историю и т.д.
-    // сейчас просто логировать:
-    console.log('[GamePage] move', event);
   }
 }

--- a/src/app/services/board-state.service.ts
+++ b/src/app/services/board-state.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BoardStateService {}

--- a/src/app/services/board-state.service.ts
+++ b/src/app/services/board-state.service.ts
@@ -22,7 +22,7 @@ export class BoardStateService {
     this._squares.set(initial);
   }
 
-  /** Узнать фигуру на клетке */
+  /** Узнать фигуру на клетке для подсветки допустимых ходов, правила шахматной логики*/
   public pieceAt(square: SquareType): PieceType | null {
     return this._squares().find((s) => s.square === square)?.piece ?? null;
   }
@@ -31,11 +31,6 @@ export class BoardStateService {
   public movePiece(payload: ChessMovePayloadType): void {
     const { from, to } = payload;
 
-    if (from === to) {
-      console.log('[movePiece] from === to → игнор', { from, to });
-      return;
-    }
-
     // игнор «хода в ту же клетку»
     if (from === to) return;
 
@@ -43,30 +38,9 @@ export class BoardStateService {
     const fromCell = list.find((s) => s.square === from);
     const toCell = list.find((s) => s.square === to);
 
-    if (from === to) {
-      console.log('[movePiece] from === to → игнор', { from, to });
-      return;
-    }
-
-    if (!fromCell) {
-      console.log('[movePiece] fromCell not found', { from });
-      return;
-    }
-    if (!fromCell.piece) {
-      console.log('[movePiece] no piece at from', { from });
-      return;
-    }
-    if (!toCell) {
-      console.log('[movePiece] toCell not found', { to });
-      return;
-    }
-    if (toCell.piece && toCell.piece.color === fromCell.piece.color) {
-      console.log('[movePiece] target has same-color piece → запрещено', {
-        to,
-        target: toCell.piece,
-      });
-      return;
-    }
+    if (!fromCell || !fromCell.piece) return;
+    if (!toCell) return;
+    if (toCell.piece && toCell.piece.color === fromCell.piece.color) return;
 
     const moved = fromCell.piece;
 
@@ -76,8 +50,6 @@ export class BoardStateService {
       if (s.square === to) return { ...s, piece: moved };
       return s;
     });
-
-    console.log('[movePiece] OK', { from, to, moved });
 
     this._squares.set(next);
   }

--- a/src/app/services/board-state.service.ts
+++ b/src/app/services/board-state.service.ts
@@ -1,6 +1,84 @@
-import { Injectable } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
+import type {
+  PieceType,
+  SquareStateType,
+  SquareType,
+} from '@/app/types/chess-square.type';
+import type { BoardOrientationType } from '@/app/types/chess-piece.type';
+import { BoardSetupService } from '@/app/services/board-setup.service';
+import type { ChessMovePayloadType } from '@/app/types/drag-drop-data.type';
 
 @Injectable({
   providedIn: 'root',
 })
-export class BoardStateService {}
+export class BoardStateService {
+  // выдает текущее состояние board
+  public readonly squares = computed(() => this._squares());
+  private readonly _squares = signal<readonly SquareStateType[]>([]);
+  private readonly boardSetup = inject(BoardSetupService);
+
+  public init(orientation: BoardOrientationType): void {
+    const initial = this.boardSetup.createInitialSquares(orientation);
+    this._squares.set(initial);
+  }
+
+  /** Узнать фигуру на клетке */
+  public pieceAt(square: SquareType): PieceType | null {
+    return this._squares().find((s) => s.square === square)?.piece ?? null;
+  }
+
+  /** Простое применение хода (без шахматной валидации) */
+  public movePiece(payload: ChessMovePayloadType): void {
+    const { from, to } = payload;
+
+    if (from === to) {
+      console.log('[movePiece] from === to → игнор', { from, to });
+      return;
+    }
+
+    // игнор «хода в ту же клетку»
+    if (from === to) return;
+
+    const list = this._squares();
+    const fromCell = list.find((s) => s.square === from);
+    const toCell = list.find((s) => s.square === to);
+
+    if (from === to) {
+      console.log('[movePiece] from === to → игнор', { from, to });
+      return;
+    }
+
+    if (!fromCell) {
+      console.log('[movePiece] fromCell not found', { from });
+      return;
+    }
+    if (!fromCell.piece) {
+      console.log('[movePiece] no piece at from', { from });
+      return;
+    }
+    if (!toCell) {
+      console.log('[movePiece] toCell not found', { to });
+      return;
+    }
+    if (toCell.piece && toCell.piece.color === fromCell.piece.color) {
+      console.log('[movePiece] target has same-color piece → запрещено', {
+        to,
+        target: toCell.piece,
+      });
+      return;
+    }
+
+    const moved = fromCell.piece;
+
+    // иммутабельное обновление
+    const next: readonly SquareStateType[] = list.map((s) => {
+      if (s.square === from) return { ...s, piece: null };
+      if (s.square === to) return { ...s, piece: moved };
+      return s;
+    });
+
+    console.log('[movePiece] OK', { from, to, moved });
+
+    this._squares.set(next);
+  }
+}

--- a/src/app/styles/variables.scss
+++ b/src/app/styles/variables.scss
@@ -17,6 +17,7 @@ $color-blue2: #273b8d;
 $color-blue3: #b6d0e2;
 $color-yellow: #ffea00;
 $color-red: #cd5c5c;
+$color-red2: #f00;
 
 /* размеры осей/доски */
 $axis: 28px;

--- a/src/app/types/chess-square.type.ts
+++ b/src/app/types/chess-square.type.ts
@@ -15,9 +15,9 @@ export type PieceType = {
 
 export type PieceColorType = 'white' | 'black';
 
-export type ColorLightType = 'var(--tui-chart-categorical-18)';
-export type ColorDarkType = 'var(--tui-background-elevation-3)';
-export type SquareColorType = ColorLightType | ColorDarkType;
+export type ColorWhiteType = 'var(--tui-chart-categorical-18)';
+export type ColorBlackType = 'var(--tui-background-elevation-3)';
+export type SquareColorType = ColorWhiteType | ColorBlackType;
 
 export type PieceKindType =
   | 'king'
@@ -51,3 +51,9 @@ export const RANKS = [
 ] as const;
 
 export type RankType = (typeof RANKS)[number];
+
+export type SquareUiStateType = SquareStateType & {
+  isFrom: boolean;
+  isOverAllowed: boolean;
+  isOverDenied: boolean;
+};

--- a/src/app/types/drag-drop-data.type.ts
+++ b/src/app/types/drag-drop-data.type.ts
@@ -1,0 +1,18 @@
+import type { PieceType, SquareType } from '@/app/types/chess-square.type';
+
+/** Что тащим (источник) */
+export type DragDataType = {
+  piece: PieceType;
+  fromSquare: SquareType;
+};
+
+/** Куда бросаем (цель) */
+export type DropDataType = {
+  square: SquareType;
+  piece: PieceType | null;
+};
+
+export type ChessMovePayloadType = {
+  from: SquareType;
+  to: SquareType;
+};

--- a/src/app/utilities/chess-piece.ts
+++ b/src/app/utilities/chess-piece.ts
@@ -4,6 +4,10 @@ import {
   RANKS,
   type RankType,
 } from '@/app/types/chess-square.type';
+import type {
+  DragDataType,
+  DropDataType,
+} from '@/app/types/drag-drop-data.type';
 
 const FILES_SET: ReadonlySet<string> = new Set(FILES);
 const RANKS_SET: ReadonlySet<number> = new Set(RANKS);
@@ -14,4 +18,25 @@ export function isFileType(value: string): value is FileType {
 
 export function isRankType(value: number): value is RankType {
   return RANKS_SET.has(value);
+}
+
+// --- Type guards ---
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function isDragData(candidate: unknown): candidate is DragDataType {
+  if (!isRecord(candidate)) return false;
+
+  return (
+    typeof candidate['fromSquare'] === 'string' &&
+    candidate['piece'] !== null &&
+    candidate['piece'] !== undefined
+  );
+}
+
+export function isDropData(candidate: unknown): candidate is DropDataType {
+  if (!isRecord(candidate)) return false;
+
+  return typeof candidate['square'] === 'string';
 }


### PR DESCRIPTION
1. Title of changes: Drag&Drop
2. Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

3. Title and number of issues: [#57](https://github.com/sorcerers-apprentices/chess/issues/57)
4. Screenshots:
<img width="689" height="682" alt="image" src="https://github.com/user-attachments/assets/33808859-fd78-48ba-a354-2d4b290ab76b" />

5. Description: 
Implement basic Drag & Drop for chess pieces using Angular CDK. A piece can be dragged from its square and dropped onto any empty square. Drops onto the same square or an occupied square are ignored (no state change). No move-legality logic (piece rules, checks, turn order, captures) is included in this phase.
Drag starts on a square with a piece.
Valid drop on an empty square moves the piece in the UI state.
Invalid drops (same/occupied) do nothing.
Visual feedback for drag is present.

7. Important notices for future work:
