### PR TITLE
Add highlighting possible chess moves

### DIFF
--- a/src/app/components/chess-board/chess-board.html
+++ b/src/app/components/chess-board/chess-board.html
@@ -13,6 +13,7 @@
         [piece]="square.piece"
         [isFrom]="square.isFrom"
         [isOverAllowed]="square.isOverAllowed"
+        [isAllowed]="square.isAllowed"
         [isOverDenied]="square.isOverDenied"
         (chessMove)="onSquareMove($event)"
         (dragStartSquare)="onDragStart($event)"

--- a/src/app/components/chess-board/chess-board.ts
+++ b/src/app/components/chess-board/chess-board.ts
@@ -78,17 +78,15 @@ export class ChessBoard {
       const isFrom = from === s.square;
       const isOver = over === s.square;
 
-      // единое правило: если allow=null → как раньше (разрешено всё, кроме from)
-      const canDropHere =
-        from !== null &&
-        s.square !== from &&
-        (allow ? allow.has(s.square) : true);
+      const isAllowed =
+        !!allow && from !== null && s.square !== from && allow.has(s.square);
 
-      const isOverAllowed = isOver && canDropHere;
-      const isOverDenied = isOver && !canDropHere;
+      const isOverAllowed = isOver && isAllowed;
+      const isOverDenied =
+        isOver && from !== null && s.square !== from && !isAllowed;
 
       // возвращаем расширенный SquareUiStateType с флагами подсветок
-      return { ...s, isFrom, isOverAllowed, isOverDenied };
+      return { ...s, isFrom, isAllowed, isOverAllowed, isOverDenied };
     });
   });
 

--- a/src/app/components/chess-square/chess-square.html
+++ b/src/app/components/chess-square/chess-square.html
@@ -12,6 +12,7 @@
   class="square"
   [class.is-from]="isFrom()"
   [class.is-over-allowed]="isOverAllowed()"
+  [class.is-allowed]="isAllowed()"
   [class.is-over-denied]="isOverDenied()"
   [class.is-empty]="!hasPiece()"
 >

--- a/src/app/components/chess-square/chess-square.scss
+++ b/src/app/components/chess-square/chess-square.scss
@@ -1,6 +1,7 @@
 @use "variables" as vars;
 
 .square {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -10,22 +11,8 @@
 
   // состояние: откуда тащим
   &.is-from {
-    outline: 3px solid var(--tui-background-accent-1);
-    outline-offset: -3px;
-  }
-
-  // состояние: можно бросить
-  &.is-over-allowed {
-    z-index: 1;
-    outline: 4px solid var(--tui-status-positive);
-    outline-offset: -4px;
-  }
-
-  // состояние: бросить нельзя
-  &.is-over-denied {
-    z-index: 1;
-    outline: 4px solid vars.$color-red2;
-    outline-offset: -4px;
+    outline: 3px solid var(--tui-status-warning);
+    outline-offset: -2px;
   }
 }
 
@@ -47,4 +34,38 @@
 
 .square.is-over-allowed .piece {
   opacity: 0;
+}
+
+/* общий оверлей */
+.square::after {
+  pointer-events: none;
+  content: "";
+  position: absolute;
+  z-index: 1; /* над базовым фоном клетки */
+  inset: 0;
+  border-radius: inherit;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+// все доступные клетки
+.square.is-allowed::after {
+  opacity: 1;
+  background-color: color-mix(
+    in srgb,
+    var(--tui-status-warning) 62%,
+    transparent
+  );
+}
+
+// состояние: можно бросить
+.square.is-over-allowed::after {
+  opacity: 1;
+  box-shadow: inset 0 0 0 4px var(--tui-status-warning);
+}
+
+// состояние: бросить нельзя
+.square.is-over-denied::after {
+  opacity: 1;
+  background-color: color-mix(in srgb, vars.$color-red2 42%, transparent);
 }

--- a/src/app/components/chess-square/chess-square.ts
+++ b/src/app/components/chess-square/chess-square.ts
@@ -47,6 +47,8 @@ export class ChessSquare {
   public readonly isOverAllowed = input<boolean>(false);
   // курсор/фигура «над этой клеткой, ход запрещён».
   public readonly isOverDenied = input<boolean>(false);
+  // возможные ходы
+  public readonly isAllowed = input<boolean>(false);
 
   public readonly fromSquare = input<SquareType | null>(null);
   public readonly allowedTargets = input<ReadonlySet<SquareType> | null>(null);

--- a/src/app/constants/chess-square.constans.ts
+++ b/src/app/constants/chess-square.constans.ts
@@ -1,32 +1,10 @@
 import type {
-  SquareType,
-  SquareColorType,
-  SquareStateType,
   ColorWhiteType,
   ColorBlackType,
 } from '@/app/types/chess-square.type';
-import { FILES, RANKS } from '@/app/types/chess-square.type';
+import { RANKS } from '@/app/types/chess-square.type';
 
 export const RANKS_TOP_DOWN = [...RANKS].reverse();
 
 export const LIGHT: ColorWhiteType = 'var(--tui-chart-categorical-18)';
 export const DARK: ColorBlackType = 'var(--tui-background-elevation-3)';
-
-/** Готовые 64 клетки с цветами */
-export const SQUARE_STATES: readonly SquareStateType[] =
-  ((): readonly SquareStateType[] => {
-    const acc: SquareStateType[] = [];
-    for (const rank of RANKS_TOP_DOWN) {
-      for (const file of FILES) {
-        const square: SquareType = `${file}${rank}`;
-
-        // Чётность по индексам из исходных массивов (без «0..7»):
-        const even = (RANKS.indexOf(rank) + FILES.indexOf(file)) % 2 === 0;
-
-        const squareColor: SquareColorType = even ? LIGHT : DARK;
-
-        acc.push({ square, squareColor, piece: null });
-      }
-    }
-    return acc;
-  })();

--- a/src/app/styles/variables.scss
+++ b/src/app/styles/variables.scss
@@ -22,7 +22,7 @@ $color-red2: #f00;
 /* размеры осей/доски */
 $axis: 28px;
 $board-min: 320px;
-$board-size: min(96vmin, 992px);
+$board-size: min(70vmin, 992px);
 $board-wrap-width: calc(#{$board-size} + #{$axis});
 $board-wrap-block: calc(var(--board-size) + var(--axis));
 $board-wrap-min: calc(#{$board-min} + #{$axis});

--- a/src/app/types/chess-square.type.ts
+++ b/src/app/types/chess-square.type.ts
@@ -56,6 +56,7 @@ export type RankType = (typeof RANKS)[number];
 
 export type SquareUiStateType = SquareStateType & {
   isFrom: boolean;
+  isAllowed: boolean;
   isOverAllowed: boolean;
   isOverDenied: boolean;
 };


### PR DESCRIPTION
1. Title of changes: Add highlighting possible chess moves
2. Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

3. Title and number of issues: [#65](https://github.com/sorcerers-apprentices/chess/issues/65)
4. Screenshots:
<img width="720" height="718" alt="image" src="https://github.com/user-attachments/assets/0daf16fc-4129-4639-97c3-e2ab189a10cf" />

5. Description: Add highlighting possible chess moves
6. Important notices for future work:
