### PR TITLE
Add opponent chess moves

### DIFF
--- a/src/app/components/game-settings/game-settings.html
+++ b/src/app/components/game-settings/game-settings.html
@@ -59,37 +59,17 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>1</td>
-            <td>e2 → e4</td>
-            <td>e2 → e4</td>
-          </tr>
-          <tr>
-            <td>2</td>
-            <td>d4</td>
-            <td>Nf6</td>
-          </tr>
-          <tr>
-            <td>1</td>
-            <td>e2 → e4</td>
-            <td>e2 → e4</td>
-          </tr>
+          @for (row of movesRows(); track row.num) {
+            <tr>
+              <td>{{ row.num }}</td>
+              <td class="player">{{ row.playerText }}</td>
+              <td class="opponent">{{ row.opponentText }}</td>
+            </tr>
+          }
         </tbody>
       </table>
     </div>
   </tui-scrollbar>
-  <!--
-   @for (row of movesRows; track row.num) {
-    <tr>
-      <td>{{ row.num }}</td>
-      <td class="player">
-          {{ row.player?.from }} → {{ row.player?.to }}
-      </td>
-      <td class="opponent">
-        {{ row.opponent?.from }} → {{ row.opponent?.to }}
-      </td>
-    </tr>
-  -->
 </div>
 <div class="game-controls">
   <button

--- a/src/app/components/game-settings/game-settings.ts
+++ b/src/app/components/game-settings/game-settings.ts
@@ -1,5 +1,16 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from '@angular/core';
 import { TuiButton, TuiIcon, TuiScrollbar } from '@taiga-ui/core';
+import { Store } from '@ngrx/store';
+import {
+  selectMoves,
+  selectOrientation,
+} from '@/app/store/selectors/game.selectors';
+import type { MoveRow } from '@/app/types/chess-piece.type';
 
 @Component({
   selector: 'app-game-settings',
@@ -8,4 +19,29 @@ import { TuiButton, TuiIcon, TuiScrollbar } from '@taiga-ui/core';
   styleUrl: './game-settings.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class GameSettings {}
+export class GameSettings {
+  public readonly movesRows = computed<MoveRow[]>(() => {
+    const list = this.moves(); // массив из стора
+    const myColor = this.orientation() === 'white' ? 'w' : 'b';
+
+    return list.map((moveRecord, index) => {
+      const isMine = moveRecord.move.color === myColor;
+      const from = moveRecord.move.from;
+      const to = moveRecord.move.to;
+
+      return {
+        num: index + 1,
+        player: isMine ? { from, to } : undefined,
+        opponent: !isMine ? { from, to } : undefined,
+        playerText: isMine ? `${from} → ${to}` : '-',
+        opponentText: !isMine ? `${from} → ${to}` : '-',
+      };
+    });
+  });
+
+  private readonly store = inject(Store);
+
+  private readonly moves = this.store.selectSignal(selectMoves);
+
+  private readonly orientation = this.store.selectSignal(selectOrientation);
+}

--- a/src/app/pages/game-page/game-page.ts
+++ b/src/app/pages/game-page/game-page.ts
@@ -19,6 +19,7 @@ import { GameService } from '@/app/services/game.service';
 import type { Square } from 'chess.js';
 import { GameSupabaseService } from '@/app/services/game-supabase.service';
 import { loadGame } from '@/app/store/actions/game.actions';
+import { OpponentRunnerService } from '@/app/services/opponent-runner.service';
 
 @Component({
   selector: 'app-game-page',
@@ -40,6 +41,7 @@ export class GamePage {
   );
   protected readonly gameSupabaseService = inject(GameSupabaseService);
   protected readonly game = inject(GameService);
+  protected readonly opponent = inject(OpponentRunnerService);
 
   protected readonly orientation = this.store.selectSignal(
     (state) => state.game.orientation,

--- a/src/app/services/opponent-runner.service.ts
+++ b/src/app/services/opponent-runner.service.ts
@@ -1,0 +1,54 @@
+import { effect, inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { GameService } from '@/app/services/game.service';
+import {
+  selectChessFen,
+  selectGameId,
+  selectIsGameOver,
+  selectOrientation,
+} from '@/app/store/selectors/game.selectors';
+import { parseActiveColor } from '@/app/utilities/chess-piece';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OpponentRunnerService {
+  private readonly store = inject(Store);
+  private readonly game = inject(GameService);
+
+  // сигналы из стора
+  private readonly fen = this.store.selectSignal(selectChessFen);
+  private readonly gameId = this.store.selectSignal(selectGameId);
+  private readonly orientation = this.store.selectSignal(selectOrientation); // 'white' | 'black'
+  private readonly isGameOver = this.store.selectSignal(selectIsGameOver);
+
+  // локальный флаг занятости (чтобы не стреляло повторно)
+  private busy = false;
+  private readonly delayMs = 1000;
+
+  private readonly autorun = effect(() => {
+    const id = this.gameId();
+    if (!id || this.busy) return;
+
+    const fen = this.fen();
+    const over = this.isGameOver?.() ?? false;
+    if (over) return;
+
+    // чей сейчас ход по FEN
+    const active = parseActiveColor(fen);
+    const me = this.orientation() === 'white' ? 'w' : 'b';
+    const opponentTurn = active !== me;
+    if (!opponentTurn) return;
+
+    this.busy = true;
+    // задержка перед ходом оппонента
+    setTimeout(() => {
+      try {
+        // локальный бот на chess.js — сам диспатчит playMove и завершает партию при необходимости
+        this.game.playOpponentMove();
+      } finally {
+        this.busy = false;
+      }
+    }, this.delayMs);
+  });
+}

--- a/src/app/store/reducers/game.reducers.ts
+++ b/src/app/store/reducers/game.reducers.ts
@@ -4,6 +4,7 @@ import {
   newGame,
   playMove,
   redoMove,
+  setGameId,
   undoMove,
 } from '@/app/store/actions/game.actions';
 import { DEFAULT_POSITION } from 'chess.js';
@@ -16,6 +17,7 @@ export const gameReducers = createReducer(
   on(newGame, (state, { initialFen, orientation }) => ({
     ...state,
     fen: initialFen ?? state.fen,
+    id: '',
     moves: [],
     undoneMoves: [],
     lastMove: null,
@@ -24,6 +26,11 @@ export const gameReducers = createReducer(
     finished: false,
     result: null,
     finalFen: null,
+  })),
+
+  on(setGameId, (state, { gameId }) => ({
+    ...state,
+    id: gameId,
   })),
 
   on(loadGameSuccess, (_state, { game }) => ({

--- a/src/app/store/selectors/game.selectors.ts
+++ b/src/app/store/selectors/game.selectors.ts
@@ -46,3 +46,13 @@ export const selectOrientation = createSelector(
   selectGameState,
   (state) => state.orientation,
 );
+
+export const selectGameId = createSelector(
+  selectGameState,
+  (state) => state.id,
+);
+
+export const selectIsGameOver = createSelector(
+  selectGameState,
+  (state) => state.finished,
+);

--- a/src/app/types/chess-piece.type.ts
+++ b/src/app/types/chess-piece.type.ts
@@ -1,1 +1,11 @@
+import type { Square } from 'chess.js';
+
 export type BoardOrientationType = 'whiteBottom' | 'whiteTop';
+
+export type MoveRow = {
+  num: number;
+  player?: { from: Square; to: Square };
+  opponent?: { from: Square; to: Square };
+  playerText: string;
+  opponentText: string;
+};

--- a/src/app/utilities/chess-piece.ts
+++ b/src/app/utilities/chess-piece.ts
@@ -8,6 +8,7 @@ import type {
   DragDataType,
   DropDataType,
 } from '@/app/types/drag-drop-data.type';
+import type { Color } from 'chess.js';
 
 const FILES_SET: ReadonlySet<string> = new Set(FILES);
 const RANKS_SET: ReadonlySet<number> = new Set(RANKS);
@@ -39,4 +40,12 @@ export function isDropData(candidate: unknown): candidate is DropDataType {
   if (!isRecord(candidate)) return false;
 
   return typeof candidate['square'] === 'string';
+}
+
+export function parseActiveColor(fen: string): Color {
+  const token = fen.split(' ')[1];
+  if (token === 'w' || token === 'b') {
+    return token;
+  }
+  throw new Error(`Invalid FEN active color: ${token}`);
 }


### PR DESCRIPTION
1. Title of changes: Add opponent chess moves
2. Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

3. Title and number of issues: [#87](https://github.com/sorcerers-apprentices/chess/issues/87)
4. Screenshots:
<img width="1208" height="780" alt="image" src="https://github.com/user-attachments/assets/b7221e3c-3f06-4777-b5ec-de6c24c832f9" />

5. Description:
- function parseActiveColor() функция —способ понять, кто сейчас ходит, основываясь на состоянии игры в виде FEN.
app\utilities\chess-piece.ts
fen.split(' ') → разбиваем строку FEN по пробелам.
[0] → позиция фигур
[1] → чей ход (w или b)
Берём [1] → token.
Если он "w" (white to move) или "b" (black to move) → возвращаем.
Если что-то странное (например, FEN битый) → кидаем ошибку.
- В gameReducers добавила поле id: '' в on(newGame)
добавила reducer on(setGameId)
- В game.selectors.ts добавила два селектора
selectGameId
selectIsGameOver
- В GamePage добавила OpponentRunnerService, так как там эффект, он срабатывает сразу при создании компонента.
- Создала сервис OpponentRunnerService
Реагирует на изменения стора (FEN, gameId, ориентация, статус конца игры) и, когда наступает очередь соперника, через небольшую задержку делает ход (вызывает game.playOpponentMove()).
Когда перезапустится эффект: при изменении FEN (любой ход), при смене gameId, при смене ориентации, при смене признака «игра окончена».
busy защищает от повторных срабатываний (дубликатов во время ожидания таймера).
delayMs — задержка перед ходом бота.
OpponentRunnerService не вычисляет сам конец партии.
Его задача — реагировать на готовый флаг из стора.
Он спрашивает у стора:
– «Игра уже закончена?»
– Если да → ничего не делает, никакие ходы соперника не запускает.
Создала тип MoveRow для читаемости и переиспользования.
6. Important notices for future work:
