### PR TITLE
Refactor game loading: use move table as source of truth instead of pgn

### DIFF
--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -8,6 +8,7 @@ import {
 import {
   selectChess,
   selectIsGameOver,
+  selectMovesCount,
   selectOrientation,
 } from '@/app/store/selectors/game.selectors';
 import type { Chess } from 'chess.js';
@@ -27,13 +28,12 @@ import type {
 } from '@/app/types/chess-type/chess-square.type';
 import { toStoredMove } from '@/app/utilities/mapping-chess-move-class';
 import { AuthService } from '@/app/services/supabase/auth.service';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 export type GameResultType = {
   winner: 'white' | 'black' | null;
   draw: boolean;
 };
-
-//export type BoardMatrix = (Piece | null)[][];
 
 @Injectable({
   providedIn: 'root',
@@ -50,6 +50,10 @@ export class GameService {
   private readonly orientation = this.store.selectSignal(selectOrientation);
   private readonly isFinished = this.store.selectSignal(selectIsGameOver);
   private readonly lastEngineMove = signal<EngineMove | null>(null);
+
+  private readonly movesCount = toSignal(this.store.select(selectMovesCount), {
+    initialValue: 0,
+  });
 
   public readonly lastEngineMoveSignal = this.lastEngineMove.asReadonly();
 
@@ -70,7 +74,7 @@ export class GameService {
       const newFen = chess.fen();
       const newPgn = chess.pgn();
 
-      const ply = chess.history().length; // после move() история уже включает этот полуход
+      const ply = this.movesCount() + 1;
       const playerId = this.auth.getUserData().user.id;
 
       const moveRecord: MoveRecordType = {
@@ -191,7 +195,7 @@ export class GameService {
 
     try {
       // текущее состояние партии
-      const chess = this.game();
+      const chess = clone(this.game());
       const fen = chess.fen();
 
       // чей ход по мнению chess.js
@@ -238,7 +242,7 @@ export class GameService {
 
       const newFen = chess.fen();
       const newPgn = chess.pgn();
-      const ply = chess.history().length;
+      const ply = this.movesCount() + 1;
 
       const moveRecord: MoveRecordType = {
         move: toStoredMove(moveResult),

--- a/src/app/services/supabase/game-supabase.service.ts
+++ b/src/app/services/supabase/game-supabase.service.ts
@@ -18,6 +18,7 @@ import type {
 export class GameSupabaseService {
   private readonly supabase = inject(SupabaseService).client;
 
+  //Game
   public async createGame(
     playerId: string,
     playerColor: 'white' | 'black',
@@ -46,7 +47,6 @@ export class GameSupabaseService {
   }
 
   public async loadGame(gameId: string): Promise<GameModel | null> {
-    //this.rememberGameIdLS(gameId);
     return await this.fetchGame(gameId);
   }
 
@@ -63,7 +63,10 @@ export class GameSupabaseService {
     }
   }
 
-  public async move(gameId: string, chess: Chess): Promise<void> {
+  public async updateGameAfterMove(
+    gameId: string,
+    chess: Chess,
+  ): Promise<void> {
     const game = await this.fetchGame(gameId);
     const oldPgn = game?.pgn;
 
@@ -81,7 +84,7 @@ export class GameSupabaseService {
     }
   }
 
-  public async toggleMove(gameId: string): Promise<GameProjection> {
+  public async undoGamePgn(gameId: string): Promise<GameProjection> {
     const game = await this.fetchGame(gameId);
     if (!game) {
       throw new Error('Game not found');
@@ -140,6 +143,7 @@ export class GameSupabaseService {
     }
   }
 
+  // Move
   public async insertMove(row: MoveDbInsert): Promise<MoveDbRow> {
     const { data, error } = await this.supabase
       .from('move')
@@ -152,6 +156,21 @@ export class GameSupabaseService {
     }
 
     return data;
+  }
+
+  public async fetchMoves(gameId: string): Promise<MoveDbRow[]> {
+    const { data, error } = await this.supabase
+      .from('move')
+      .select('*')
+      .eq('game_id', gameId)
+      .order('ply', { ascending: true });
+
+    if (error) {
+      console.error('[fetchMoves] Supabase error:', error);
+      throw new Error(error.message);
+    }
+    // Supabase может вернуть null вместо массива
+    return data ?? [];
   }
 
   private async fetchGame(id: string): Promise<GameModel | null> {

--- a/src/app/store/effects/game.effects.ts
+++ b/src/app/store/effects/game.effects.ts
@@ -18,21 +18,16 @@ import {
 } from '@/app/store/actions/game.actions';
 import { catchError, from, map, of, switchMap, tap } from 'rxjs';
 import { AuthService } from '@/app/services/supabase/auth.service';
-import type {
-  GameDomainType,
-  MoveRecordType,
-} from '@/app/store/states/game.state';
-import { Chess } from 'chess.js';
 import { load } from '@/app/utilities/chess-piece';
 import { Router } from '@angular/router';
-import type { HistoryMoveVerbose } from '@/app/types/chess-type/chess-game.type';
-import { toStoredMoveFromHistory } from '@/app/utilities/mapping-chess-move-class';
 import { Store } from '@ngrx/store';
 import type { AppStateType } from '@/app/store/states/app.state';
 import { concatLatestFrom } from '@ngrx/operators';
 import { selectGameId } from '@/app/store/selectors/game.selectors';
 import type { MoveDbInsert } from '@/app/types/supabase-type/supabase-move.type';
+import { toMoveDbRow } from '@/app/types/supabase-type/supabase-move.type';
 import { toMoveDbInsert } from '@/app/types/supabase-type/supabase-move.type';
+import { buildGameDomain } from '@/app/types/supabase-type/supebase-game-domain-builder';
 
 @Injectable({
   providedIn: 'root',
@@ -84,56 +79,18 @@ export class GameEffects {
       ofType(loadGame),
       switchMap(({ gameId }) => {
         return from(this.api.loadGame(gameId)).pipe(
-          map((game) => {
+          switchMap((game) => {
             if (game === null) {
-              return gameApiErrorActions.loadGameFailed({
-                error: 'Game not found',
-              });
+              return of(
+                gameApiErrorActions.loadGameFailed({ error: 'Game not found' }),
+              );
             }
-            const chess = new Chess();
-            const pgn = game.pgn;
-            chess.loadPgn(pgn);
-            const moves: HistoryMoveVerbose[] = chess.history({
-              verbose: true,
-            });
 
-            const lastMove = moves.at(-1);
-            const gameModel: GameDomainType = {
-              pgn: chess.pgn(),
-              pgnLast: game.pgn_last,
-              fen: game.fen,
-              id: game.id,
-              moves: moves.map((move, index) => {
-                const stored = toStoredMoveFromHistory(move);
-                const record: MoveRecordType = {
-                  move: stored,
-                  fenAfter: stored.after,
-
-                  // НОВОЕ — чтобы тип был валиден
-                  ply: index + 1,
-                  player_id: null,
-                  is_check: false,
-                  is_checkmate: false,
-                };
-                return record;
-              }),
-              undoneMoves: [],
-              lastMove: lastMove
-                ? { from: lastMove.from, to: lastMove.to }
-                : null,
-              orientation: game.player_color,
-              finished: game.finished,
-              result:
-                game.result === 'DRAW'
-                  ? { winner: null, draw: true }
-                  : game.result === 'WHITE_WINS'
-                    ? { winner: 'white', draw: false }
-                    : game.result === 'BLACK_WINS'
-                      ? { winner: 'black', draw: false }
-                      : { winner: null, draw: false },
-              finalFen: game.fen_final,
-            };
-            return loadGameSuccess({ game: gameModel });
+            return from(this.api.fetchMoves(gameId)).pipe(
+              map((rows) => rows.map(toMoveDbRow)),
+              map((moveRecords) => buildGameDomain(game, moveRecords)),
+              map((gameModel) => loadGameSuccess({ game: gameModel })),
+            );
           }),
           catchError((error: unknown) => {
             const message =
@@ -145,6 +102,7 @@ export class GameEffects {
     );
   });
 
+  //отправяет ход в таблицу move в БД
   private move$ = createEffect(() => {
     return this.actions$.pipe(
       ofType(playMove),
@@ -162,7 +120,7 @@ export class GameEffects {
 
         const insert: MoveDbInsert = toMoveDbInsert(gameId, moveRecord);
 
-        return from(this.api.move(gameId, chess)).pipe(
+        return from(this.api.updateGameAfterMove(gameId, chess)).pipe(
           switchMap(() => from(this.api.insertMove(insert))),
           map(() => moveSuccess()),
           catchError((error: unknown) => {
@@ -187,7 +145,7 @@ export class GameEffects {
             }),
           );
         }
-        return from(this.api.toggleMove(gameId)).pipe(
+        return from(this.api.undoGamePgn(gameId)).pipe(
           map((result) => undoMoveSuccess(result)),
           catchError((error: unknown) => {
             const message =
@@ -212,7 +170,7 @@ export class GameEffects {
           );
         }
 
-        return from(this.api.toggleMove(gameId)).pipe(
+        return from(this.api.undoGamePgn(gameId)).pipe(
           map((result) => redoMoveSuccess(result)),
           catchError((error: unknown) => {
             const message =

--- a/src/app/store/selectors/game.selectors.ts
+++ b/src/app/store/selectors/game.selectors.ts
@@ -93,3 +93,8 @@ export const selectGameId = createSelector(
   selectGameState,
   (state) => state.id,
 );
+
+export const selectMovesCount = createSelector(
+  selectGameState,
+  (state) => state.moves.length,
+);

--- a/src/app/types/supabase-type/supebase-game-domain-builder.ts
+++ b/src/app/types/supabase-type/supebase-game-domain-builder.ts
@@ -1,0 +1,39 @@
+import type { GameModel } from '@/app/types/supabase-type/supabase-game.type';
+import type {
+  GameDomainType,
+  MoveRecordType,
+} from '@/app/store/states/game.state';
+import type { GameResultType } from '@/app/services/game.service';
+
+export function buildGameDomain(
+  game: GameModel,
+  moveRecords: MoveRecordType[],
+): GameDomainType {
+  const last = moveRecords.at(-1);
+
+  const result: GameResultType | null =
+    game.result === 'DRAW'
+      ? { winner: null, draw: true }
+      : game.result === 'WHITE_WINS'
+        ? { winner: 'white', draw: false }
+        : game.result === 'BLACK_WINS'
+          ? { winner: 'black', draw: false }
+          : { winner: null, draw: false };
+
+  return {
+    id: game.id,
+    fen: game.fen,
+    pgn: game.pgn,
+    pgnLast: game.pgn_last,
+
+    moves: moveRecords,
+    undoneMoves: [],
+
+    lastMove: last ? { from: last.move.from, to: last.move.to } : null,
+
+    orientation: game.player_color,
+    finished: game.finished,
+    result,
+    finalFen: game.fen_final,
+  };
+}

--- a/src/app/utilities/chess-piece.ts
+++ b/src/app/utilities/chess-piece.ts
@@ -48,9 +48,6 @@ export const clone = (prev: Chess): Chess => {
 
   curr.loadPgn(prev.pgn());
 
-  // const moves = prev.history({ verbose: true });
-  // moves.forEach((move) => curr.move(move));
-
   return curr;
 };
 


### PR DESCRIPTION
1. Title of changes: Refactor game loading: use move table as source of truth instead of pgn
2. Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

3. Title and number of issues:
4. Screenshots:
5. Description: Refactor game loading: use move table as source of truth instead of pgn
6. Important notices for future work:
